### PR TITLE
Remove Reload.js script tag

### DIFF
--- a/expressSampleApp/public/index.html
+++ b/expressSampleApp/public/index.html
@@ -5,7 +5,5 @@
   </head>
   <body>
     <h1>Reload Express Sample App</h1>
-    <!-- All you have to do is include the reload script and have it be on every page of your project -->
-    <script src="/reload/reload.js"></script>
   </body>
 </html>


### PR DESCRIPTION
The reload.js tag is being inserted into the document from the reload-server.js, therefore there is no need to have it in the html file.